### PR TITLE
Fix TestServerAction for methods parameters (#43)

### DIFF
--- a/src/Acheve.TestHost/HttpResponseMessageExtensions.cs
+++ b/src/Acheve.TestHost/HttpResponseMessageExtensions.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace System.Net.Http
@@ -19,6 +20,13 @@ namespace System.Net.Http
             var content = await response.Content.ReadAsStringAsync();
 
             throw new Exception($"Response status does not indicate success: {response.StatusCode:D} ({response.StatusCode}); \r\n{content}");
+        }
+
+        public static async Task<T> ReadContentAsAsync<T>(this HttpResponseMessage responseMessage)
+        {
+            var json = await responseMessage.Content.ReadAsStringAsync();
+
+            return JsonConvert.DeserializeObject<T>(json);
         }
     }
 }

--- a/src/Acheve.TestHost/Routing/TestServerAction.cs
+++ b/src/Acheve.TestHost/Routing/TestServerAction.cs
@@ -13,7 +13,6 @@ namespace Acheve.TestHost.Routing
 
         public Dictionary<int, TestServerArgument> ArgumentValues { get; private set; }
 
-
         public TestServerAction(MethodInfo methodInfo)
         {
             MethodInfo = methodInfo ?? throw new ArgumentNullException(nameof(methodInfo));
@@ -44,6 +43,7 @@ namespace Acheve.TestHost.Routing
                             ArgumentValues.Add(order, new TestServerArgument(constant.Value?.ToString(), isFromBody, isFromForm, isFromHeader, argument.Name));
                         }
                         break;
+
                     case MemberExpression member when member.NodeType == ExpressionType.MemberAccess:
                         {
                             var instance = Expression.Lambda(member)
@@ -53,6 +53,14 @@ namespace Acheve.TestHost.Routing
                             ArgumentValues.Add(order, new TestServerArgument(instance, isFromBody, isFromForm, isFromHeader, argument.Name));
                         }
                         break;
+
+                    case MethodCallExpression method:
+                        {
+                            var instance = Expression.Lambda(method).Compile().DynamicInvoke();
+                            ArgumentValues.Add(order, new TestServerArgument(instance, isFromBody, isFromForm, isFromHeader, argument.Name));
+                        }
+                        break;
+
                     default: return;
                 }
             }

--- a/src/Acheve.TestHost/Routing/Tokenizers/PrimitiveParameterActionTokenizer.cs
+++ b/src/Acheve.TestHost/Routing/Tokenizers/PrimitiveParameterActionTokenizer.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
 namespace Acheve.TestHost.Routing.Tokenizers
 {
-    class PrimitiveParameterActionTokenizer
+    internal class PrimitiveParameterActionTokenizer
         : ITokenizer
     {
         public void AddTokens<TController>(TestServerAction action, TestServerTokenCollection tokens)
@@ -15,27 +16,37 @@ namespace Acheve.TestHost.Routing.Tokenizers
 
             for (var i = 0; i < parameters.Length; i++)
             {
-                if ((parameters[i].ParameterType.IsPrimitive
-                    ||
-                    parameters[i].ParameterType == typeof(string)
-                    ||
-                    parameters[i].ParameterType == typeof(decimal)
-                    ||
-                    parameters[i].ParameterType == typeof(Guid))
-                    && !IgnoreHeader(parameters[i]))
+                if (!IgnoreHeader(parameters[i]))
                 {
-                    var tokenName = parameters[i].Name.ToLowerInvariant();
-                    var tokenValue = action.ArgumentValues[i].Instance;
-
-                    if (tokenValue != null)
+                    if (IsPrimitiveType(parameters[i].ParameterType))
                     {
-                        tokens.AddToken(tokenName, tokenValue.ToString(), isConventional: false);
+                        var tokenName = parameters[i].Name.ToLowerInvariant();
+                        var tokenValue = action.ArgumentValues[i].Instance;
+
+                        if (tokenValue != null)
+                        {
+                            tokens.AddToken(tokenName, tokenValue.ToString(), isConventional: false);
+                        }
+                    }
+                    else if (parameters[i].ParameterType.IsArray
+                       && IsPrimitiveType(parameters[i].ParameterType.GetElementType()))
+                    {
+                        var arrayValues = (Array)action.ArgumentValues[i].Instance;
+
+                        if (arrayValues != null
+                            && arrayValues.Length != 0
+                            )
+                        {
+                            var tokenName = parameters[i].Name.ToLowerInvariant();
+                            var tokenValue = GetTokenValue(arrayValues, tokenName);
+                            tokens.AddToken(tokenName, tokenValue, isConventional: false);
+                        }
                     }
                 }
             }
         }
 
-        bool IgnoreHeader(ParameterInfo parameter)
+        private bool IgnoreHeader(ParameterInfo parameter)
         {
             var attributes = parameter.GetCustomAttributes(false);
 
@@ -45,6 +56,26 @@ namespace Acheve.TestHost.Routing.Tokenizers
             }
 
             return false;
+        }
+
+        private bool IsPrimitiveType(Type type)
+        {
+            return type.IsPrimitive
+                || type == typeof(string)
+                || type == typeof(decimal)
+                || type == typeof(Guid);
+        }
+
+        private string GetTokenValue(Array array, string tokenName)
+        {
+            var list = new List<string>();
+
+            foreach (var element in array)
+            {
+                list.Add(element.ToString());
+            }
+
+            return string.Join($"&{tokenName}=", list);
         }
     }
 }

--- a/tests/UnitTests/Acheve.TestHost/Routing/Builders/BugsController.cs
+++ b/tests/UnitTests/Acheve.TestHost/Routing/Builders/BugsController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using System;
+using UnitTests.Acheve.TestHost.Routing.Models;
 
 namespace UnitTests.Acheve.TestHost.Builders
 {
@@ -9,7 +10,7 @@ namespace UnitTests.Acheve.TestHost.Builders
         : ControllerBase
     {
         [HttpGet("{param1}/{param2}")]
-        public IActionResult GuidSupport(string param1,Guid param2)
+        public IActionResult GuidSupport(string param1, Guid param2)
         {
             return Ok();
         }
@@ -18,6 +19,30 @@ namespace UnitTests.Acheve.TestHost.Builders
         public IActionResult UnderDashSupport(Guid param_1, int param_2)
         {
             return Ok();
+        }
+
+        [HttpGet("arrayGuid")]
+        public ActionResult<Guid[]> GuidArraySupport([FromQuery] Guid[] param1)
+        {
+            return Ok(param1);
+        }
+
+        [HttpGet("arrayInt")]
+        public ActionResult<int[]> IntArraySupport([FromQuery] int[] param1)
+        {
+            return Ok(param1);
+        }
+
+        [HttpGet("arrayString")]
+        public ActionResult<string[]> StringArraySupport([FromQuery] string[] param1)
+        {
+            return Ok(param1);
+        }
+
+        [HttpGet("arrayPerson")]
+        public ActionResult<int[]> PersonArraySupport([FromQuery] Person[] param1)
+        {
+            return Ok(param1);
         }
     }
 }

--- a/tests/UnitTests/Acheve.TestHost/Routing/Models/Person.cs
+++ b/tests/UnitTests/Acheve.TestHost/Routing/Models/Person.cs
@@ -1,0 +1,8 @@
+﻿namespace UnitTests.Acheve.TestHost.Routing.Models
+{
+    public class Person
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+    }
+}

--- a/tests/UnitTests/Acheve.TestHost/Routing/TestServerExtensionsTests.cs
+++ b/tests/UnitTests/Acheve.TestHost/Routing/TestServerExtensionsTests.cs
@@ -2,12 +2,14 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.TestHost;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 using UnitTests.Acheve.TestHost.Builders;
+using UnitTests.Acheve.TestHost.Routing.Models;
 using Xunit;
 
 namespace UnitTests.Acheve.TestHost.Routing
@@ -1342,6 +1344,152 @@ namespace UnitTests.Acheve.TestHost.Routing
 
             request.GetConfiguredAddress()
                 .Should().Be($"api/bugs/{guid}/10");
+        }
+
+        [Fact]
+        public async Task create_request_supporting_guid_array_types_on_parameters()
+        {
+            var server = new TestServerBuilder()
+                .UseDefaultStartup()
+                .Build();
+
+            var guidList = new List<Guid> {
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            };
+
+            var array = guidList.ToArray();
+
+            var request = server.CreateHttpApiRequest<BugsController>(
+                actionSelector: controller => controller.GuidArraySupport(array),
+                tokenValues: null,
+                contentOptions: new NotIncludeContent());
+
+            var responseMessage = await request.GetAsync();
+
+            responseMessage.EnsureSuccessStatusCode();
+            var response = await responseMessage.ReadContentAsAsync<Guid[]>();
+
+            response.Should().NotBeNull();
+            response.Count().Should().Be(3);
+        }
+
+        [Fact]
+        public async Task create_request_supporting_int_array_types_on_parameters()
+        {
+            var server = new TestServerBuilder()
+                .UseDefaultStartup()
+                .Build();
+
+            int[] array = { 1, 3, 5, 7, 9 };
+
+            var request = server.CreateHttpApiRequest<BugsController>(
+                actionSelector: controller => controller.IntArraySupport(array),
+                tokenValues: null,
+                contentOptions: new NotIncludeContent());
+
+            var responseMessage = await request.GetAsync();
+
+            responseMessage.EnsureSuccessStatusCode();
+            var response = await responseMessage.ReadContentAsAsync<int[]>();
+
+            response.Should().NotBeNull();
+            response.Count().Should().Be(5);
+        }
+
+        [Fact]
+        public async Task create_request_not_supporting_class_array_types_on_parameters()
+        {
+            var server = new TestServerBuilder()
+                .UseDefaultStartup()
+                .Build();
+
+            var array = new Person[] {
+                new Person { FirstName = "john", LastName = "walter" },
+                new Person { FirstName = "john2", LastName = "walter2" }
+            };
+
+            var request = server.CreateHttpApiRequest<BugsController>(
+                actionSelector: controller => controller.PersonArraySupport(array),
+                tokenValues: null,
+                contentOptions: new NotIncludeContent());
+
+            var responseMessage = await request.GetAsync();
+
+            responseMessage.EnsureSuccessStatusCode();
+            var response = await responseMessage.ReadContentAsAsync<Person[]>();
+
+            response.Should().NotBeNull();
+            response.Count().Should().Be(0);
+        }
+
+        [Fact]
+        public async Task create_request_supporting_string_array_types_on_parameters()
+        {
+            var server = new TestServerBuilder()
+                .UseDefaultStartup()
+                .Build();
+
+            string[] array = { "one", "two", "three" };
+
+            var request = server.CreateHttpApiRequest<BugsController>(
+                actionSelector: controller => controller.StringArraySupport(array),
+                tokenValues: null,
+                contentOptions: new NotIncludeContent());
+
+            var responseMessage = await request.GetAsync();
+
+            responseMessage.EnsureSuccessStatusCode();
+            var response = await responseMessage.ReadContentAsAsync<string[]>();
+
+            response.Should().NotBeNull();
+            response.Count().Should().Be(3);
+        }
+
+        [Fact]
+        public async Task create_request_supporting_guid_array_types_on_parameters_seding_method()
+        {
+            var server = new TestServerBuilder()
+                .UseDefaultStartup()
+                .Build();
+
+            var guidList = new List<Guid> {
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            };
+
+            var request = server.CreateHttpApiRequest<BugsController>(
+                actionSelector: controller => controller.GuidArraySupport(guidList.ToArray()),
+                tokenValues: null,
+                contentOptions: new NotIncludeContent());
+
+            var responseMessage = await request.GetAsync();
+
+            responseMessage.EnsureSuccessStatusCode();
+            var response = await responseMessage.ReadContentAsAsync<Guid[]>();
+
+            response.Should().NotBeNull();
+            response.Count().Should().Be(3);
+        }
+
+        [Fact]
+        public void create_request_supporting_send_method_on_client_http()
+        {
+            var server = new TestServerBuilder()
+                .UseDefaultStartup()
+                .Build();
+
+            var guid = Guid.NewGuid().ToString();
+
+            var request = server.CreateHttpApiRequest<BugsController>(
+                actionSelector: controller => controller.GuidSupport("prm1", Guid.Parse(guid)),
+                tokenValues: null,
+                contentOptions: new NotIncludeContent());
+
+            request.GetConfiguredAddress()
+                .Should().Be($"api/bugs/prm1/{guid}");
         }
 
         private class PrivateNonControllerClass


### PR DESCRIPTION
* Fix TestServerAction for methods parameters

* Merge With VFA91 Fork

* Add Guid[] In QueryParams

* Avoid add parameter when Guid[] is empty

* Adding Test

* using GuidArrayExtension

* Remove unused method

* fix for .net5

* Fixing comments

* Enable any array from query params

* Avoid Array with not primitives types

* fix for .net 3.1

* comments fix

* Change namespace & Clear function for primitives

* remove dynamic

* rename variables

Co-authored-by: Alexis Martin Peña <alexis.martin@barrabes.biz>
Co-authored-by: Sergio <sergio11_92@hotmail.com>